### PR TITLE
Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=it">Itapano</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
 # Code Auditor CTF
 ![image](https://github.com/user-attachments/assets/fdfbbffc-71f9-4463-856d-aca054399a0f)
 


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=en)
- [繁體中文](https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=zh-TW)
- [日本語](https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=20urc3&project=auditor.codes&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌

> OpenAiTx is an open soucre & free & no Ads project https://github.com/OpenAiTx/OpenAiTx.
